### PR TITLE
Match non-annotated tags as well as annotated ones

### DIFF
--- a/makeversion.sh
+++ b/makeversion.sh
@@ -19,7 +19,7 @@ elif [ $# != 0 ];then
 fi
 
 # Get the git repository version number
-REPO=$(git describe --dirty --always)
+REPO=$(git describe --dirty --always --tags)
 
 # Get the build time stamp
 WHEN=$(date +"%Y-%m-%d %H:%M:%S")


### PR DESCRIPTION
The `--tags` argument of git describe will match non-annotated tags.
This works with `--always`.

This is a minor addition that seems very much in the spirit of this repository.

Another suggestion would be to add `--broken` as well.